### PR TITLE
Fix station search to support CRS shortcode matching

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -37,7 +37,7 @@ function searchAllStations(query, limit = 6) {
     .filter(
       (s) =>
         s.stationName.toLowerCase().includes(q) ||
-        s.crsCode.toLowerCase() === q
+        s.crsCode.toLowerCase().includes(q)
     )
     .slice(0, limit)
 }
@@ -86,7 +86,7 @@ export default function Home() {
           .filter(
             (s) =>
               s.name.toLowerCase().includes(search.toLowerCase()) ||
-              s.crs.toLowerCase() === search.toLowerCase()
+              s.crs.toLowerCase().includes(search.toLowerCase())
           )
           .slice(0, 8)
       : []


### PR DESCRIPTION
Fix station search fields to filter on both station names and CRS shortcodes using partial matching.

Previously CRS code matching used strict equality, requiring users to type the full exact shortcode. Now uses .includes() so partial shortcode input works (e.g. "BH" matches BHI, BHM).

Closes #2

Generated with [Claude Code](https://claude.ai/code)