### PR TITLE
Add inline delete confirmation for quick routes

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -55,6 +55,7 @@ export default function Home() {
 
   // Custom routes
   const [customRoutes, setCustomRoutes] = useState([])
+  const [confirmDeleteId, setConfirmDeleteId] = useState(null)
   const [showAdd, setShowAdd] = useState(false)
   const [addName, setAddName] = useState('')
   const [addFrom, setAddFrom] = useState(null)
@@ -188,28 +189,50 @@ export default function Home() {
           {customRoutes.map((r) => (
             <div
               key={r.id}
-              className="preset-card custom-route-card"
-              onClick={() => router.push(`/station/${r.from.crs}${r.to ? `?to=${r.to.crs}` : ''}`)}
+              className={`preset-card custom-route-card${confirmDeleteId === r.id ? ' custom-route-card--confirming' : ''}`}
+              onClick={() => { if (confirmDeleteId !== r.id) router.push(`/station/${r.from.crs}${r.to ? `?to=${r.to.crs}` : ''}`) }}
             >
-              <div style={{ flex: 1, minWidth: 0 }}>
-                <div className="preset-card-label">{r.label || 'My route'}</div>
-                <div className="preset-card-route">
-                  {r.from.name}
-                  {r.to && (
-                    <>
-                      <span className="preset-card-arrow"> → </span>
-                      {r.to.name}
-                    </>
-                  )}
+              {confirmDeleteId === r.id ? (
+                <div className="route-delete-confirm">
+                  <span className="route-delete-confirm-text">Delete this route?</span>
+                  <div className="route-delete-confirm-actions">
+                    <button
+                      className="route-delete-confirm-cancel"
+                      onClick={(e) => { e.stopPropagation(); setConfirmDeleteId(null) }}
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      className="route-delete-confirm-delete"
+                      onClick={(e) => { e.stopPropagation(); removeRoute(r.id); setConfirmDeleteId(null) }}
+                    >
+                      Delete
+                    </button>
+                  </div>
                 </div>
-              </div>
-              <button
-                className="route-delete-btn"
-                onClick={(e) => { e.stopPropagation(); removeRoute(r.id) }}
-                aria-label="Remove route"
-              >
-                ×
-              </button>
+              ) : (
+                <>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div className="preset-card-label">{r.label || 'My route'}</div>
+                    <div className="preset-card-route">
+                      {r.from.name}
+                      {r.to && (
+                        <>
+                          <span className="preset-card-arrow"> → </span>
+                          {r.to.name}
+                        </>
+                      )}
+                    </div>
+                  </div>
+                  <button
+                    className="route-delete-btn"
+                    onClick={(e) => { e.stopPropagation(); setConfirmDeleteId(r.id) }}
+                    aria-label="Remove route"
+                  >
+                    ×
+                  </button>
+                </>
+              )}
             </div>
           ))}
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -668,6 +668,58 @@ body {
   opacity: 1;
 }
 
+.custom-route-card--confirming {
+  cursor: default;
+}
+
+.custom-route-card--confirming:active {
+  opacity: 1;
+}
+
+.route-delete-confirm {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  gap: 10px;
+}
+
+.route-delete-confirm-text {
+  font-size: 14px;
+  color: var(--label-primary);
+  font-weight: 500;
+  flex: 1;
+  min-width: 0;
+}
+
+.route-delete-confirm-actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.route-delete-confirm-cancel,
+.route-delete-confirm-delete {
+  border: none;
+  border-radius: 8px;
+  padding: 6px 12px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  font-family: var(--font);
+  -webkit-tap-highlight-color: transparent;
+}
+
+.route-delete-confirm-cancel {
+  background: var(--fill);
+  color: var(--label-primary);
+}
+
+.route-delete-confirm-delete {
+  background: var(--red);
+  color: #fff;
+}
+
 .add-route-btn {
   background: var(--bg-secondary);
   border: 1.5px dashed var(--fill);


### PR DESCRIPTION
When the delete button is tapped on a quick route card, the card now shows an inline "Delete this route?" prompt with Cancel and Delete buttons instead of deleting immediately.

Closes #4

Generated with [Claude Code](https://claude.ai/code)