### PR TITLE
feat: show quick routes in 2-column grid

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -198,7 +198,7 @@ export default function Home() {
         {/* Quick Routes */}
         <div className="section-header">Quick Routes</div>
 
-        <div className="preset-grid">
+        <div className="quick-routes-grid">
           {/* Built-in presets */}
           {presets.map((p, i) => (
             <PresetCard

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -633,6 +633,19 @@ body {
   padding: 16px 0 40px;
 }
 
+/* ─── Quick routes 2-column grid ────────────────────────────────── */
+
+.quick-routes-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.quick-routes-grid .add-route-btn,
+.quick-routes-grid .add-route-form {
+  grid-column: 1 / -1;
+}
+
 /* ─── Custom routes ──────────────────────────────────────────────── */
 
 .custom-route-card {


### PR DESCRIPTION
Condenses the Quick Routes section into a 2-wide grid to save space, since cards now show compact CRS codes. The "Add route" button and form span both columns.

Closes #17

Generated with [Claude Code](https://claude.ai/code)