### PR TITLE
Add edit toggle on quick routes

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -54,6 +54,7 @@ export default function Home() {
 
   // Custom routes
   const [customRoutes, setCustomRoutes] = useState([])
+  const [editMode, setEditMode] = useState(false)
   const [showAdd, setShowAdd] = useState(false)
   const [addName, setAddName] = useState('')
   const [addFrom, setAddFrom] = useState(null)
@@ -196,7 +197,14 @@ export default function Home() {
         )}
 
         {/* Quick Routes */}
-        <div className="section-header">Quick Routes</div>
+        <div className="section-header-row">
+          <span className="section-header" style={{ padding: 0 }}>Quick Routes</span>
+          {customRoutes.length > 0 && (
+            <button className="section-edit-btn" onClick={() => setEditMode((v) => !v)}>
+              {editMode ? 'Done' : 'Edit'}
+            </button>
+          )}
+        </div>
 
         <div className="quick-routes-grid">
           {/* Built-in presets */}
@@ -227,13 +235,15 @@ export default function Home() {
                   )}
                 </div>
               </div>
-              <button
-                className="route-delete-btn"
-                onClick={(e) => { e.stopPropagation(); if (window.confirm('Delete this route?')) removeRoute(r.id) }}
-                aria-label="Remove route"
-              >
-                ×
-              </button>
+              {editMode && (
+                <button
+                  className="route-delete-btn"
+                  onClick={(e) => { e.stopPropagation(); if (window.confirm('Delete this route?')) removeRoute(r.id) }}
+                  aria-label="Remove route"
+                >
+                  ×
+                </button>
+              )}
             </div>
           ))}
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -633,6 +633,31 @@ body {
   padding: 16px 0 40px;
 }
 
+/* ─── Section header row (with optional action button) ──────────── */
+
+.section-header-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 0 8px;
+}
+
+.section-edit-btn {
+  background: none;
+  border: none;
+  color: var(--blue);
+  font-size: 15px;
+  font-weight: 400;
+  font-family: var(--font);
+  cursor: pointer;
+  padding: 0;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.section-edit-btn:active {
+  opacity: 0.55;
+}
+
 /* ─── Quick routes 2-column grid ────────────────────────────────── */
 
 .quick-routes-grid {


### PR DESCRIPTION
Adds an Edit/Done toggle button next to the Quick Routes section header. The button only appears when custom routes exist. Delete buttons are hidden by default and shown only in edit mode.

Closes #19

Generated with [Claude Code](https://claude.ai/code)